### PR TITLE
enable prediction data flag in the hdbscan model

### DIFF
--- a/denseclus/DenseClus.py
+++ b/denseclus/DenseClus.py
@@ -68,6 +68,14 @@ class DenseClus(BaseEstimator, ClassifierMixin):
                 See:
                   https://umap-learn.readthedocs.io/en/latest/composing_models.html
 
+            prediction_data: bool, default=False
+                Whether to generate extra cached data for predicting labels or
+                membership vectors few new unseen points later. If you wish to
+                persist the clustering object for later re-use you probably want
+                to set this to True.
+                See:
+                 https://hdbscan.readthedocs.io/en/latest/soft_clustering.html
+
             verbose : bool, default=False
                 Level of verbosity to print when fitting and predicting.
                 Setting to False will only show Warnings that appear.
@@ -82,6 +90,7 @@ class DenseClus(BaseEstimator, ClassifierMixin):
         n_components: int = None,
         cluster_selection_method: str = "eom",
         umap_combine_method: str = "intersection",
+        prediction_data: bool = False,
         verbose: bool = False,
     ):
 
@@ -92,6 +101,7 @@ class DenseClus(BaseEstimator, ClassifierMixin):
         self.n_components = n_components
         self.cluster_selection_method = cluster_selection_method
         self.umap_combine_method = umap_combine_method
+        self.prediction_data = prediction_data
 
         if verbose:
             logger.setLevel(logging.DEBUG)
@@ -206,6 +216,7 @@ class DenseClus(BaseEstimator, ClassifierMixin):
             min_samples=self.min_samples,
             min_cluster_size=self.min_cluster_size,
             cluster_selection_method=self.cluster_selection_method,
+            prediction_data=self.prediction_data,
             gen_min_span_tree=True,
             metric="euclidean",
         ).fit(self.mapper_.embedding_)


### PR DESCRIPTION
*Issue #, if available:*
Currently, there is no support for soft clustering. 

*Description of changes:*
In order to use soft clustering, the hdbscan model needs to init with prediction_data=True (default is False).
this PR gives the user the option to pass this variable when init the class DenseClus.

for more info: https://hdbscan.readthedocs.io/en/latest/soft_clustering.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
